### PR TITLE
Corrected volume code for voxel dimensions

### DIFF
--- a/3d-imaging-exploratory-data-analysis/exercises/3-dataset-eda/solution/Exercise. Volume Dataset Analysis.ipynb
+++ b/3d-imaging-exploratory-data-analysis/exercises/3-dataset-eda/solution/Exercise. Volume Dataset Analysis.ipynb
@@ -592,16 +592,14 @@
     "    sid = inst[1].SeriesInstanceUID\n",
     "    if (sid not in volumes):\n",
     "        volumes[sid] = dict()\n",
+    "        volumes[sid]['slice_count'] = 0\n",
     "        \n",
     "    volumes[sid][\"StudyDate\"] = inst[1].StudyDate\n",
     "    volumes[sid][\"Width\"] = inst[1].Columns\n",
     "    volumes[sid][\"Height\"] = inst[1].Rows\n",
     "    volumes[sid][\"PatientId\"] = inst[1].PatientID\n",
     "    \n",
-    "    if (\"slice_count\" not in volumes[sid]):\n",
-    "        volumes[sid][\"slice_count\"] = 0\n",
-    "    else:\n",
-    "        volumes[sid][\"slice_count\"] += 1"
+    "    volumes[sid][\"slice_count\"] += 1"
    ]
   },
   {


### PR DESCRIPTION
```
for inst in instances:
    sid = inst[1].SeriesInstanceUID
    if (sid not in volumes):
        volumes[sid] = dict()
        
    volumes[sid]["StudyDate"] = inst[1].StudyDate
    volumes[sid]["Width"] = inst[1].Columns
    volumes[sid]["Height"] = inst[1].Rows
    volumes[sid]["PatientId"] = inst[1].PatientID
    
    if ("slice_count" not in volumes[sid]):
        volumes[sid]["slice_count"] = 0
    else:
        volumes[sid]["slice_count"] += 1
```
In your code above, in each volume, the slice count is one less than expected.  You can sanity check as the actual number of Knee MR are 36 but this code will output 35 and similarly for others.
You can correct this using following:
```
volumes = dict()
for inst in instances:
    sid = inst[1].SeriesInstanceUID
    if(sid not in volumes):
        volumes[sid] = dict()
        volumes[sid]['slice_count'] = 0
    volumes[sid]['Width'] = inst[1].Columns
    volumes[sid]['Height'] = inst[1].Rows
    volumes[sid]['PatientID'] = inst[1].PatientID
    volumes[sid]['StudyDate'] = inst[1].StudyDate
    
    volumes[sid]['slice_count'] += 1
```